### PR TITLE
fix: Add server-side session to persist privacy option the user has selected

### DIFF
--- a/app/components/SignManifesto.vue
+++ b/app/components/SignManifesto.vue
@@ -18,14 +18,18 @@ const signWith = async (provider: 'github' | 'linkedin') => {
   showPrivacyDialog.value = false
   
   try {
-    const params = new URLSearchParams({
-      privacy: privacyLevel.value,
-      showProfilePic: showProfilePic.value.toString(),
+    // persist privacy settings through oAuth
+    await $fetch('/api/auth/privacy-session', {
+      method: 'POST',
+      body: {
+        privacyLevel: privacyLevel.value,
+        showProfilePic: showProfilePic.value,
+      },
     })
     
-    await navigateTo(`/auth/${provider}?${params.toString()}`, { external: true })
+    await navigateTo(`/auth/${provider}`, { external: true })
   } catch (error) {
-    console.error('Sign in error:', error)
+    console.error('Privacy session error:', error)
     signingProvider.value = null
   }
 }
@@ -41,6 +45,9 @@ onMounted(() => {
   } else if (route.query.signed === 'already') {
     showMessage.value = 'You have already signed this manifesto.'
     messageType.value = 'info'
+  } else if (route.query.error === 'github_missing_privacy' || route.query.error === 'linkedin_missing_privacy') {
+    showMessage.value = 'Privacy settings were lost. Please try signing again.'
+    messageType.value = 'error'
   } else if (route.query.error) {
     showMessage.value = 'There was an error signing the manifesto. Please try again.'
     messageType.value = 'error'

--- a/auth.d.ts
+++ b/auth.d.ts
@@ -38,6 +38,9 @@ declare module '#auth-utils' {
       profile?: string
     }
     loggedInAt?: Date
+    privacyLevel?: 'full' | 'first_name' | 'anonymous'
+    showProfilePic?: boolean
+    timestamp?: number
   }
 
   type SecureSessionData = {

--- a/server/api/auth/privacy-session.post.ts
+++ b/server/api/auth/privacy-session.post.ts
@@ -1,0 +1,34 @@
+import { z } from 'zod'
+import { setPrivacySession } from '../../utils/privacy-session'
+import { PrivacySessionSchema } from '../../utils/validation'
+
+export default defineEventHandler(async (event) => {
+  if (!isMethod(event, 'POST')) {
+    throw createError({
+      statusCode: 405,
+      statusMessage: 'Method Not Allowed',
+    })
+  }
+
+  try {
+    const body = await readBody(event)
+    const validatedData = PrivacySessionSchema.parse(body)
+
+    await setPrivacySession(event, validatedData)
+
+    return { success: true }
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: 'Invalid privacy data',
+        data: error.issues,
+      })
+    }
+    
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Failed to set privacy session',
+    })
+  }
+})

--- a/server/utils/privacy-session.ts
+++ b/server/utils/privacy-session.ts
@@ -1,0 +1,44 @@
+import type { PrivacyLevel } from '#shared/utils/signee-display'
+
+export type PrivacySessionData = {
+  privacyLevel: PrivacyLevel
+  showProfilePic: boolean
+  timestamp: number
+}
+
+export async function setPrivacySession (event: any, privacyData: {
+  privacyLevel: PrivacyLevel
+  showProfilePic: boolean
+}) {
+  await setUserSession(event, {
+    privacyLevel: privacyData.privacyLevel,
+    showProfilePic: privacyData.showProfilePic,
+    timestamp: Date.now(),
+  })
+}
+
+export async function getPrivacySession (event: any): Promise<PrivacySessionData | null> {
+  const session = await getUserSession(event)
+  
+  if (!session?.privacyLevel || !session?.timestamp) {
+    return null
+  }
+  
+  const timeToExpire = 30 * 60 * 1000
+  const isExpired = Date.now() - (session.timestamp as number) > timeToExpire
+
+  if (isExpired) {
+    await clearPrivacySession(event)
+    return null
+  }
+
+  return {
+    privacyLevel: session.privacyLevel as PrivacyLevel,
+    showProfilePic: session.showProfilePic as boolean,
+    timestamp: session.timestamp as number,
+  }
+}
+
+export async function clearPrivacySession (event: any) {
+  await clearUserSession(event)
+}

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -5,6 +5,17 @@ export const ProviderSchema = z.enum([
   'linkedin',
 ])
 
+export const PrivacyLevelSchema = z.enum([
+  'full',
+  'first_name',
+  'anonymous',
+])
+
+export const PrivacySessionSchema = z.object({
+  privacyLevel: PrivacyLevelSchema,
+  showProfilePic: z.boolean(),
+})
+
 export const SigneeInputSchema = z.object({
   providerId: z.string(),
   provider: ProviderSchema,
@@ -14,11 +25,7 @@ export const SigneeInputSchema = z.object({
   displayName: z.string().optional().nullable(),
   avatarUrl: z.string(),
   profileUrl: z.string(),
-  privacyLevel: z.enum([
-    'full',
-    'first_name',
-    'anonymous',
-  ]).default('full'),
+  privacyLevel: PrivacyLevelSchema.default('full'),
   showProfilePic: z.boolean().default(true),
   userHash: z.string().optional().nullable(),
 })
@@ -33,11 +40,7 @@ export const PublicSigneeSchema = z.object({
   avatarUrl: z.string(),
   profileUrl: z.string(),
   firstName: z.string().optional().nullable(),
-  privacyLevel: z.enum([
-    'full',
-    'first_name', 
-    'anonymous',
-  ]).optional(),
+  privacyLevel: PrivacyLevelSchema.optional(),
   showProfilePic: z.boolean().optional(),
 })
 


### PR DESCRIPTION
This PR resolves and fixes issue #9. 

It adds a privacy session instead of using parameters to transport the selected privacy option, which got lost through the oAuth flow. Now we have a server-side session that resolves the issue. The database is filled correctly and the user shows up as expected. 

