### PR TITLE
feat: add function based testing with refactored types using zod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,6 @@ jobs:
 
       - name: Type check
         run: pnpm run test:types
+
+      - name: Run tests
+        run: pnpm test

--- a/app/components/Signees.vue
+++ b/app/components/Signees.vue
@@ -1,27 +1,6 @@
 <script setup lang="ts">
-type Signee = {
-  id: string
-  displayName?: string
-  avatarUrl: string
-  profileUrl: string
-  firstName?: string
-  privacyLevel?: 'full' | 'first_name' | 'anonymous'
-  showProfilePic?: boolean
-}
-
-type SigneesResponse = {
-  signees: Signee[]
-  total: number
-  page: number
-  limit: number
-  totalPages: number
-  hasNextPage: boolean
-  hasPrevPage: boolean
-}
-
-type SigneeStats = {
-  total: number
-}
+import type { PublicSignee, SigneeStats, SigneesResponse } from '../../server/utils/validation'
+import { getSigneeDisplayData } from '#shared/utils/signee-display'
 
 const config = useRuntimeConfig()
 const currentPage = ref(1)
@@ -55,18 +34,19 @@ const goToPage = (page: number) => {
 }
 
 const displayData = computed(() => {
-  return signeesData.value.signees.map(signee => ({
+  return signeesData.value.signees.map((signee: PublicSignee, index: number) => ({
     signee,
     display: getSigneeDisplayData(signee, true),
+    key: `${currentPage.value}-${index}`,
   }))
 })
 
 const clickableSignees = computed(() => {
-  return displayData.value.filter(item => item.display.isClickable)
+  return displayData.value.filter((item: any) => item.display.isClickable)
 })
 
 const nonClickableSignees = computed(() => {
-  return displayData.value.filter(item => !item.display.isClickable)
+  return displayData.value.filter((item: any) => !item.display.isClickable)
 })
 
 // Auto-refresh every 3 minutes
@@ -115,7 +95,7 @@ onUnmounted(() => {
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3  gap-6 mb-4">
         <a
           v-for="item in clickableSignees"
-          :key="item.signee.id"
+          :key="item.key"
           :href="item.display.profileUrl"
           target="_blank"
           rel="noopener noreferrer"
@@ -135,7 +115,7 @@ onUnmounted(() => {
         </a>
         <div
           v-for="item in nonClickableSignees"
-          :key="item.signee.id"
+          :key="item.key"
           class="card signee-card"
           :title="item.display.name"
         >

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "preview": "nuxt preview",
     "seed:clear": "npx tsx scripts/seed-test-data.ts clear",
     "seed:test": "npx tsx scripts/seed-test-data.ts",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "test:types": "npx nuxt typecheck",
     "vercel-build": "prisma generate && prisma migrate deploy && nuxt build",
     "prepare": "husky"
@@ -49,10 +51,13 @@
     "prisma": "^6.13.0",
     "prisma-zod-generator": "^1.1.1",
     "typescript": "5.8.3",
+    "vitest": "^3.2.4",
     "vue-eslint-parser": "^10.2.0"
   },
-    "pnpm": {
-    "ignoredBuiltDependencies": ["@prisma/client"]
+  "pnpm": {
+    "ignoredBuiltDependencies": [
+      "@prisma/client"
+    ]
   },
   "lint-staged": {
     "*.{js,ts,vue}": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       typescript:
         specifier: 5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@24.2.0)(jiti@2.5.1)(terser@5.43.1)(yaml@2.8.1)
       vue-eslint-parser:
         specifier: ^10.2.0
         version: 10.2.0(eslint@9.32.0(jiti@2.5.1))
@@ -1612,6 +1615,12 @@ packages:
   '@types/bytes@3.1.5':
     resolution: {integrity: sha512-VgZkrJckypj85YxEsEavcMmmSOIzkUHqWmM4CCyia5dc54YwsXzJ5uT4fYxBQNEXx+oF1krlhgCbvfubXqZYsQ==}
 
+  '@types/chai@5.2.2':
+    resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1761,6 +1770,35 @@ packages:
     peerDependencies:
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0
       vue: ^3.2.25
+
+  '@vitest/expect@3.2.4':
+    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/mocker@3.2.4':
+    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.4':
+    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+
+  '@vitest/runner@3.2.4':
+    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+
+  '@vitest/snapshot@3.2.4':
+    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+
+  '@vitest/spy@3.2.4':
+    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+
+  '@vitest/utils@3.2.4':
+    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
 
   '@volar/language-core@2.4.22':
     resolution: {integrity: sha512-gp4M7Di5KgNyIyO903wTClYBavRt6UyFNpc5LWfyZr1lBsTUY+QrVZfmbNF2aCyfklBOVk9YC4p+zkwoyT7ECg==}
@@ -1968,6 +2006,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   ast-kit@2.1.1:
     resolution: {integrity: sha512-mfh6a7gKXE8pDlxTvqIc/syH/P3RkzbOF6LeHdcKztLEzYe6IMsRCL7N8vI7hqTGWNxpkCuuRTpT21xNWqhRtQ==}
     engines: {node: '>=20.18.0'}
@@ -2128,6 +2170,10 @@ packages:
     resolution: {integrity: sha512-wljhAjDDIv/hM2FzgJnYQg90AWmZMNtESCjTeLH680qTzdo0nErlCxOmgzgX4ZsZAtIvqHyD87ES8QyriXB+BQ==}
     engines: {node: '>=18'}
 
+  chai@5.2.1:
+    resolution: {integrity: sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -2135,6 +2181,10 @@ packages:
   chalk@5.5.0:
     resolution: {integrity: sha512-1tm8DTaJhPBG3bIkVeZt1iZM9GfSX2lzOeDVZH9R9ffRHpmHvxZ/QhgQH/aDTkswQVt+YHdXAdS/In/30OjCbg==}
     engines: {node: ^12.17.0 || ^14.13 || >=16.0.0}
+
+  check-error@2.1.1:
+    resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -2445,6 +2495,10 @@ packages:
 
   decache@4.6.2:
     resolution: {integrity: sha512-2LPqkLeu8XWHU8qNCS3kcF6sCcb5zIzvWaAHYSvPfwhdd7mHuah29NssMzrTYyHN4F5oFy2ko9OBYxegtU0FEw==}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deep-equal@1.0.1:
     resolution: {integrity: sha512-bHtC0iYvWhyaTzvV3CZgPeZQqCOBGyGsVV7v4eevpdkLHfiSrXUdBG+qAuSz4RI70sszvjQ1QSZ98An1yNwpSw==}
@@ -2789,6 +2843,10 @@ packages:
   execa@9.6.0:
     resolution: {integrity: sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==}
     engines: {node: ^18.19.0 || >=20.5.0}
+
+  expect-type@1.2.2:
+    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+    engines: {node: '>=12.0.0'}
 
   exsolve@1.0.7:
     resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
@@ -3502,6 +3560,9 @@ packages:
     resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
     engines: {node: '>= 12.0.0'}
 
+  loupe@3.2.0:
+    resolution: {integrity: sha512-2NCfZcT5VGVNX9mSZIxLRkEAegDGBpuQZBy13desuHeVORmBDyAET4TkJr4SjqQy3A8JDofMN6LpkK8Xcm/dlw==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
@@ -4026,6 +4087,10 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -4588,6 +4653,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -4662,6 +4730,9 @@ packages:
 
   stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
@@ -4817,12 +4888,30 @@ packages:
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.0.1:
     resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
 
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.3:
+    resolution: {integrity: sha512-t2T/WLB2WRgZ9EpE4jgPJ9w+i66UZfDc8wHh0xrwiRNN+UwH98GIJkTeZqX9rg0i0ptwzqW+uYeIF0T4F8LR7A==}
+    engines: {node: '>=14.0.0'}
 
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
@@ -5174,6 +5263,34 @@ packages:
       yaml:
         optional: true
 
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.4
+      '@vitest/ui': 3.2.4
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
@@ -5223,6 +5340,11 @@ packages:
   which@5.0.0:
     resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   winston-transport@4.9.0:
@@ -6974,6 +7096,12 @@ snapshots:
 
   '@types/bytes@3.1.5': {}
 
+  '@types/chai@5.2.2':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -7179,6 +7307,48 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.29
       vite: 7.0.6(@types/node@24.2.0)(jiti@2.5.1)(terser@5.43.1)(yaml@2.8.1)
       vue: 3.5.18(typescript@5.8.3)
+
+  '@vitest/expect@3.2.4':
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.1
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.4(vite@7.0.6(@types/node@24.2.0)(jiti@2.5.1)(terser@5.43.1)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.17
+    optionalDependencies:
+      vite: 7.0.6(@types/node@24.2.0)(jiti@2.5.1)(terser@5.43.1)(yaml@2.8.1)
+
+  '@vitest/pretty-format@3.2.4':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.4':
+    dependencies:
+      '@vitest/utils': 3.2.4
+      pathe: 2.0.3
+      strip-literal: 3.0.0
+
+  '@vitest/snapshot@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      magic-string: 0.30.17
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.4':
+    dependencies:
+      tinyspy: 4.0.3
+
+  '@vitest/utils@3.2.4':
+    dependencies:
+      '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.0
+      tinyrainbow: 2.0.0
 
   '@volar/language-core@2.4.22':
     dependencies:
@@ -7456,6 +7626,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  assertion-error@2.0.1: {}
+
   ast-kit@2.1.1:
     dependencies:
       '@babel/parser': 7.28.0
@@ -7620,12 +7792,22 @@ snapshots:
 
   case-anything@3.1.2: {}
 
+  chai@5.2.1:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.1
+      deep-eql: 5.0.2
+      loupe: 3.2.0
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
   chalk@5.5.0: {}
+
+  check-error@2.1.1: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -7918,6 +8100,8 @@ snapshots:
   decache@4.6.2:
     dependencies:
       callsite: 1.0.0
+
+  deep-eql@5.0.2: {}
 
   deep-equal@1.0.1: {}
 
@@ -8302,6 +8486,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.1
+
+  expect-type@1.2.2: {}
 
   exsolve@1.0.7: {}
 
@@ -9062,6 +9248,8 @@ snapshots:
       ms: 2.1.3
       safe-stable-stringify: 2.5.0
       triple-beam: 1.4.1
+
+  loupe@3.2.0: {}
 
   lru-cache@10.4.3: {}
 
@@ -9900,6 +10088,8 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pathval@2.0.1: {}
+
   pend@1.2.0: {}
 
   perfect-debounce@1.0.0: {}
@@ -10497,6 +10687,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-git@3.28.0:
@@ -10568,6 +10760,8 @@ snapshots:
   speakingurl@14.0.1: {}
 
   stack-trace@0.0.10: {}
+
+  stackback@0.0.2: {}
 
   standard-as-callback@2.1.0: {}
 
@@ -10759,12 +10953,22 @@ snapshots:
 
   tiny-invariant@1.3.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyexec@1.0.1: {}
 
   tinyglobby@0.2.14:
     dependencies:
       fdir: 6.4.6(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.3: {}
 
   tmp-promise@3.0.3:
     dependencies:
@@ -11085,6 +11289,47 @@ snapshots:
       terser: 5.43.1
       yaml: 2.8.1
 
+  vitest@3.2.4(@types/node@24.2.0)(jiti@2.5.1)(terser@5.43.1)(yaml@2.8.1):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.0.6(@types/node@24.2.0)(jiti@2.5.1)(terser@5.43.1)(yaml@2.8.1))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.2.1
+      debug: 4.4.1
+      expect-type: 1.2.2
+      magic-string: 0.30.17
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.14
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.0.6(@types/node@24.2.0)(jiti@2.5.1)(terser@5.43.1)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@24.2.0)(jiti@2.5.1)(terser@5.43.1)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.2.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vscode-uri@3.1.0: {}
 
   vue-bundle-renderer@2.1.2:
@@ -11138,6 +11383,11 @@ snapshots:
   which@5.0.0:
     dependencies:
       isexe: 3.1.1
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   winston-transport@4.9.0:
     dependencies:

--- a/scripts/seed-test-data.ts
+++ b/scripts/seed-test-data.ts
@@ -6,23 +6,13 @@
 
 import { PrismaClient } from '@prisma/client'
 import { createUserHash } from '../server/utils/privacy'
+import type { SigneeInput } from '../server/utils/validation'
 
 const prisma = new PrismaClient()
 
-type PrivacyLevel = 'full' | 'first_name' | 'anonymous'
-
-interface TestSignee {
-  displayName: string
-  provider: 'github' | 'linkedin'
-  providerId: string
-  username: string | null
-  firstName: string | null
-  lastName: string | null
-  avatarUrl: string
-  profileUrl: string
-  privacyLevel: PrivacyLevel
-  showProfilePic: boolean
-  userHash?: string
+// Use SigneeInput type from validation schema, but make displayName required for seed data
+interface TestSignee extends Omit<SigneeInput, 'displayName'> {
+  displayName: string // Always required in seed data (matches our new requirement)
 }
 
 // Mix of privacy levels to test all scenarios

--- a/server/utils/privacy-session.ts
+++ b/server/utils/privacy-session.ts
@@ -1,10 +1,4 @@
-import type { PrivacyLevel } from '#shared/utils/signee-display'
-
-export type PrivacySessionData = {
-  privacyLevel: PrivacyLevel
-  showProfilePic: boolean
-  timestamp: number
-}
+import type { PrivacyLevel, PrivacySessionData } from './validation'
 
 export async function setPrivacySession (event: any, privacyData: {
   privacyLevel: PrivacyLevel

--- a/server/utils/privacy.ts
+++ b/server/utils/privacy.ts
@@ -1,22 +1,5 @@
 import { createHash } from 'crypto'
-import type { PrivacyLevel } from '#shared/utils/signee-display'
-
-export type PrivacyOptions = {
-  privacyLevel: PrivacyLevel
-  showProfilePic: boolean
-}
-
-export type UserData = {
-  id: string | number
-  name?: string
-  login?: string
-  given_name?: string
-  family_name?: string
-  avatar_url?: string
-  picture?: string
-  html_url?: string
-  profileUrl?: string
-}
+import type { PrivacyOptions, UserData } from './validation'
 
 export function createUserHash (providerId: string, provider: string): string {
   return createHash('sha256')
@@ -101,4 +84,4 @@ export function processSigneeData (
   }
 }
 
-export { getSigneeDisplayData as getDisplayData } from '#shared/utils/signee-display'
+export { getSigneeDisplayData as getDisplayData } from '../../shared/utils/signee-display'

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -11,10 +11,12 @@ export const PrivacyLevelSchema = z.enum([
   'anonymous',
 ])
 
-export const PrivacySessionSchema = z.object({
+export const BasePrivacySchema = z.object({
   privacyLevel: PrivacyLevelSchema,
   showProfilePic: z.boolean(),
 })
+
+export const PrivacySessionSchema = BasePrivacySchema
 
 export const SigneeInputSchema = z.object({
   providerId: z.string(),
@@ -36,13 +38,11 @@ export const PaginationSchema = z.object({
 })
 
 export const PublicSigneeSchema = z.object({
-  displayName: z.string().nullable(),
+  displayName: z.string(),
   avatarUrl: z.string(),
   profileUrl: z.string(),
   firstName: z.string().optional().nullable(),
-  privacyLevel: PrivacyLevelSchema.optional(),
-  showProfilePic: z.boolean().optional(),
-})
+}).extend(BasePrivacySchema.partial().shape)
 
 export const SigneesResponseSchema = z.object({
   signees: z.array(PublicSigneeSchema),
@@ -58,5 +58,48 @@ export const SigneeStatsSchema = z.object({
   total: z.number(),
 })
 
+export const SigneeDisplayDataSchema = z.object({
+  name: z.string(),
+  avatar: z.string(),
+  profileUrl: z.string(),
+  isClickable: z.boolean().optional(),
+})
+
+export const SigneeDataSchema = z.object({
+  displayName: z.string(),
+  firstName: z.string().optional().nullable(),
+  avatarUrl: z.string(),
+  profileUrl: z.string(),
+}).extend(BasePrivacySchema.partial().shape)
+
+export const UserDataSchema = z.object({
+  id: z.union([
+    z.string(),
+    z.number(),
+  ]),
+  name: z.string().optional(),
+  login: z.string().optional(),
+  given_name: z.string().optional(),
+  family_name: z.string().optional(),
+  avatar_url: z.string().optional(),
+  picture: z.string().optional(),
+  html_url: z.string().optional(),
+  profileUrl: z.string().optional(),
+})
+
+export const PrivacySessionDataSchema = z.object({
+  privacyLevel: PrivacyLevelSchema,
+  showProfilePic: z.boolean(),
+  timestamp: z.number(),
+})
+
+export type PrivacyLevel = z.infer<typeof PrivacyLevelSchema>
+export type PrivacyOptions = z.infer<typeof PrivacySessionSchema>
+export type UserData = z.infer<typeof UserDataSchema>
+export type PrivacySessionData = z.infer<typeof PrivacySessionDataSchema>
+export type SigneeInput = z.infer<typeof SigneeInputSchema>
+export type PublicSignee = z.infer<typeof PublicSigneeSchema>
 export type SigneesResponse = z.infer<typeof SigneesResponseSchema>
 export type SigneeStats = z.infer<typeof SigneeStatsSchema>
+export type SigneeDisplayData = z.infer<typeof SigneeDisplayDataSchema>
+export type SigneeData = z.infer<typeof SigneeDataSchema>

--- a/shared/utils/signee-display.ts
+++ b/shared/utils/signee-display.ts
@@ -1,20 +1,4 @@
-export type PrivacyLevel = 'full' | 'first_name' | 'anonymous'
-
-export type SigneeDisplayData = {
-  name: string
-  avatar: string
-  profileUrl: string
-  isClickable?: boolean
-}
-
-export type SigneeData = {
-  displayName?: string
-  firstName?: string
-  avatarUrl?: string
-  profileUrl?: string
-  privacyLevel?: PrivacyLevel
-  showProfilePic?: boolean
-}
+import type { SigneeData, SigneeDisplayData } from '../../server/utils/validation'
 
 export function getSigneeDisplayData (
   signee: SigneeData,
@@ -31,7 +15,7 @@ export function getSigneeDisplayData (
   
   switch (privacyLevel) {
     case 'full':
-      result.name = signee.displayName || 'Unknown'
+      result.name = signee.displayName
       result.avatar = signee.showProfilePic ? signee.avatarUrl || '/anonymous-avatar.svg' : '/anonymous-avatar.svg'
       result.profileUrl = signee.profileUrl || '#'
       if (includeClickable) {
@@ -40,7 +24,7 @@ export function getSigneeDisplayData (
       break
 
     case 'first_name':
-      result.name = signee.firstName || signee.displayName || 'Unknown'
+      result.name = signee.firstName || signee.displayName
       result.avatar = signee.showProfilePic ? signee.avatarUrl || '/anonymous-avatar.svg' : '/anonymous-avatar.svg'
       result.profileUrl = '#'
       if (includeClickable) {

--- a/tests/__fixtures__/user-data.ts
+++ b/tests/__fixtures__/user-data.ts
@@ -1,0 +1,54 @@
+import type { PublicSignee, SigneeData, UserData } from '../../server/utils/validation'
+
+export const mockGitHubUser: UserData = {
+  id: '12345',
+  login: 'timnit',
+  name: 'Timnit Gebru',
+  avatar_url: 'https://github.com/avatars/timnit.jpg',
+  html_url: 'https://github.com/timnit',
+}
+
+export const mockLinkedInUser: UserData = {
+  id: '67890',
+  given_name: 'Kate',
+  family_name: 'Crawford',
+  picture: 'https://linkedin.com/avatars/katecrawford.jpg',
+}
+
+export const mockPublicSignee: PublicSignee = {
+  displayName: 'Timnit Gebru',
+  avatarUrl: 'https://github.com/avatars/timnit.jpg',
+  profileUrl: 'https://github.com/timnit',
+  firstName: 'Timnit',
+  privacyLevel: 'full',
+  showProfilePic: true,
+}
+
+export const mockProcessedSigneeData = {
+  fullPrivacy: {
+    displayName: 'Timnit Gebru',
+    firstName: 'Timnit',
+    avatarUrl: 'https://github.com/avatars/timnit.jpg',
+    profileUrl: 'https://github.com/timnit',
+    privacyLevel: 'full' as const,
+    showProfilePic: true,
+  } satisfies SigneeData,
+  
+  firstNamePrivacy: {
+    displayName: 'Kate', 
+    firstName: 'Kate',
+    avatarUrl: 'https://linkedin.com/avatars/katecrawford.jpg',
+    profileUrl: '#',
+    privacyLevel: 'first_name' as const,
+    showProfilePic: true,
+  } satisfies SigneeData,
+  
+  anonymousPrivacy: {
+    displayName: 'Anonymous Supporter',
+    firstName: null,
+    avatarUrl: '/anonymous-avatar.svg',
+    profileUrl: '#',
+    privacyLevel: 'anonymous' as const,
+    showProfilePic: false,
+  } satisfies SigneeData,
+}

--- a/tests/utils/privacy.test.ts
+++ b/tests/utils/privacy.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { createUserHash, processSigneeData } from '../../server/utils/privacy'
+import type { PrivacyOptions } from '../../server/utils/validation'
+import { mockGitHubUser, mockLinkedInUser } from '../__fixtures__/user-data'
+
+describe('privacy testing', () => {
+  describe('createConsistentHash', () => {
+    it('works', () => {
+      const hash1 = createUserHash('12345', 'github')
+      const hash2 = createUserHash('12345', 'github')
+      
+      expect(hash1).toBe(hash2)
+      expect(hash1).toHaveLength(64) 
+    })
+   
+    it('different hashes', () => {
+      const githubHash = createUserHash('12345', 'github')
+      const linkedinHash = createUserHash('12345', 'linkedin')
+      const differentUserHash = createUserHash('67890', 'github')
+      
+      expect(githubHash).not.toBe(linkedinHash)
+      expect(githubHash).not.toBe(differentUserHash)
+    })
+  })
+
+  describe('processSigneeData', () => {
+    it('github - full privacy', () => {
+      const options: PrivacyOptions = { privacyLevel: 'full', showProfilePic: true }
+      const result = processSigneeData(mockGitHubUser, 'github', options)
+      
+      expect(result).toEqual({
+        providerId: '12345',
+        provider: 'github',
+        username: 'timnit',
+        firstName: 'Timnit',
+        lastName: 'Gebru',
+        displayName: 'Timnit Gebru',
+        avatarUrl: 'https://github.com/avatars/timnit.jpg',
+        profileUrl: 'https://github.com/timnit',
+        privacyLevel: 'full',
+        showProfilePic: true,
+        userHash: null,
+      })
+    })
+
+    it('linkedin - first name privacy', () => {
+      const options: PrivacyOptions = { privacyLevel: 'first_name', showProfilePic: true }
+      const result = processSigneeData(mockLinkedInUser, 'linkedin', options)
+      
+      expect(result).toEqual({
+        providerId: '67890',
+        provider: 'linkedin',
+        username: null,
+        firstName: 'Kate',
+        lastName: null,
+        displayName: 'Kate',
+        avatarUrl: 'https://linkedin.com/avatars/katecrawford.jpg',
+        profileUrl: '#',
+        privacyLevel: 'first_name',
+        showProfilePic: true,
+        userHash: null,
+      })
+    })
+
+    it('linkedin - first name privacy no profile pic', () => {
+      const options: PrivacyOptions = { privacyLevel: 'first_name', showProfilePic: false }
+      const result = processSigneeData(mockLinkedInUser, 'linkedin', options)
+      
+      expect(result).toEqual({
+        providerId: '67890',
+        provider: 'linkedin',
+        username: null,
+        firstName: 'Kate',
+        lastName: null,
+        displayName: 'Kate',
+        avatarUrl: '/anonymous-avatar.svg',
+        profileUrl: '#',
+        privacyLevel: 'first_name',
+        showProfilePic: false,
+        userHash: null,
+      })
+    })
+
+    it('github - anonymous', () => {
+      const options: PrivacyOptions = { privacyLevel: 'anonymous', showProfilePic: false }
+      const result = processSigneeData(mockGitHubUser, 'github', options)
+      
+      expect(result).toEqual({
+        providerId: expect.stringMatching(/^anon_[a-f0-9]{8}$/),
+        provider: 'github',
+        username: null,
+        firstName: null,
+        lastName: null,
+        displayName: 'Anonymous Supporter',
+        avatarUrl: '/anonymous-avatar.svg',
+        profileUrl: '#',
+        privacyLevel: 'anonymous',
+        showProfilePic: false,
+        userHash: expect.stringMatching(/^[a-f0-9]{64}$/),
+      })
+    })
+
+    it('hide profile pic', () => {
+      const options: PrivacyOptions = { privacyLevel: 'full', showProfilePic: false }
+      const result = processSigneeData(mockGitHubUser, 'github', options)
+      
+      expect(result.avatarUrl).toBe('/anonymous-avatar.svg')
+      expect(result.showProfilePic).toBe(false)
+    })
+  })
+})

--- a/tests/utils/signee-display.test.ts
+++ b/tests/utils/signee-display.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { getSigneeDisplayData } from '../../shared/utils/signee-display'
+import type { SigneeData } from '../../server/utils/validation'
+import { mockProcessedSigneeData } from '../__fixtures__/user-data'
+
+describe('signee display testing', () => {
+  describe('getSigneeDisplayData', () => {
+    it('github - full privacy', () => {
+      const result = getSigneeDisplayData(mockProcessedSigneeData.fullPrivacy, true)
+        
+      expect(result).toEqual({
+        name: 'Timnit Gebru',
+        avatar: 'https://github.com/avatars/timnit.jpg',
+        profileUrl: 'https://github.com/timnit',
+        isClickable: true,
+      })
+    })
+
+    it('linkedin - first name privacy', () => {
+      const result = getSigneeDisplayData(mockProcessedSigneeData.firstNamePrivacy, true)
+        
+      expect(result).toEqual({
+        name: 'Kate',
+        avatar: 'https://linkedin.com/avatars/katecrawford.jpg',
+        profileUrl: '#',
+        isClickable: false,
+      })
+    })
+
+    it('github - anonymous privacy', () => {
+      const result = getSigneeDisplayData(mockProcessedSigneeData.anonymousPrivacy, true)
+        
+      expect(result).toEqual({
+        name: 'Anonymous Supporter',
+        avatar: '/anonymous-avatar.svg',
+        profileUrl: '#',
+        isClickable: false,
+      })
+    })
+
+    it('hide profile pic', () => {
+      const signeeWithHiddenPic: SigneeData = {
+        ...mockProcessedSigneeData.fullPrivacy,
+        showProfilePic: false,
+      }
+        
+      const result = getSigneeDisplayData(signeeWithHiddenPic)
+        
+      expect(result.avatar).toBe('/anonymous-avatar.svg')
+    })
+
+    it('card isClickable is false', () => {
+      const result = getSigneeDisplayData(mockProcessedSigneeData.fullPrivacy, false)
+        
+      expect(result).not.toHaveProperty('isClickable')
+    })
+  })
+})
+

--- a/tests/utils/validation.test.ts
+++ b/tests/utils/validation.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { PublicSigneeSchema, SigneesResponseSchema } from '../../server/utils/validation'
+import { mockPublicSignee } from '../__fixtures__/user-data'
+
+describe('validation schemas', () => {
+
+  it('validate signee data', () => {
+    const result = PublicSigneeSchema.parse(mockPublicSignee)
+      
+    expect(result).toEqual({
+      displayName: 'Timnit Gebru',
+      avatarUrl: 'https://github.com/avatars/timnit.jpg',
+      profileUrl: 'https://github.com/timnit',
+      firstName: 'Timnit',
+      privacyLevel: 'full',
+      showProfilePic: true,
+    })
+  })
+
+  it('validate signee response', () => {
+    const mockResponse = {
+      signees: [mockPublicSignee],
+      total: 1,
+      page: 1,
+      limit: 20,
+      totalPages: 1,
+      hasNextPage: false,
+      hasPrevPage: false,
+    }
+      
+    const result = SigneesResponseSchema.parse(mockResponse)
+    expect(result.signees).toHaveLength(1)
+    expect(result.total).toBe(1)
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
+
+export default defineConfig({
+  test: {
+    // Intentionally set to node - decided not to use nuxt module for test utils
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      // seems to be needed to get shard dir working
+      '#shared': resolve(__dirname, './shared'),
+      '~': resolve(__dirname, './'),
+    },
+  },
+})


### PR DESCRIPTION
This PR resolves the issue #8.  

This PR introduces function based testing using vitest.  

**Scope:** 

- Privacy tests
- Privacy Display tests
- Validation tests 


**Further archivements:**

- Consitency in data flow through all fields
- Unify and cleanup types through zod validation file and export form there
- Update seed for testing accordingly 


The tests are added to the ci as well. 
